### PR TITLE
fix: dashboard API auth — nginx forwards X-API-Key, fix mock fallbacks

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -7,6 +7,6 @@ RUN node ./node_modules/typescript/bin/tsc -b && node ./node_modules/vite/bin/vi
 
 FROM nginx:alpine
 COPY --from=build /app/dist /usr/share/nginx/html
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY nginx.conf /etc/nginx/conf.d/default.conf.template
 EXPOSE 80
-CMD ["nginx", "-g", "daemon off;"]
+CMD ["/bin/sh", "-c", "envsubst '$OPENINSURE_API_KEY' < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"]

--- a/dashboard/nginx.conf
+++ b/dashboard/nginx.conf
@@ -18,6 +18,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-API-Key $OPENINSURE_API_KEY;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";

--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -11,6 +11,11 @@ client.interceptors.request.use((config) => {
   if (role) {
     config.headers['X-User-Role'] = role;
   }
+  // API key for dev/testing — in production, nginx injects this header server-side
+  const apiKey = import.meta.env.VITE_API_KEY;
+  if (apiKey) {
+    config.headers['X-API-Key'] = apiKey;
+  }
   return config;
 });
 

--- a/dashboard/src/api/products.ts
+++ b/dashboard/src/api/products.ts
@@ -99,8 +99,15 @@ export async function getProducts(): Promise<ProductDetail[]> {
 }
 
 export async function getProduct(id: string): Promise<ProductDetail> {
-  const { data } = await client.get(`/products/${id}`);
-  return data;
+  try {
+    const { data } = await client.get(`/products/${id}`);
+    return data;
+  } catch (error) {
+    console.warn('[API] getProduct fallback:', error);
+    const mp = (mockProducts as unknown as ProductDetail[]).find((p) => p.id === id);
+    if (mp) return mp;
+    throw error;
+  }
 }
 
 export async function createProduct(body: Partial<ProductDetail>): Promise<ProductDetail> {

--- a/dashboard/src/api/submissions.ts
+++ b/dashboard/src/api/submissions.ts
@@ -52,13 +52,8 @@ export async function getSubmission(id: string): Promise<Submission | undefined>
 }
 
 export async function createSubmission(payload: Record<string, unknown>): Promise<Submission> {
-  try {
-    const { data } = await client.post<Submission>('/submissions', payload);
-    return data;
-  } catch (error) {
-    console.warn('[API] Falling back to demo data:', error);
-    return { id: `mock-${Date.now()}`, ...payload } as unknown as Submission;
-  }
+  const { data } = await client.post<Submission>('/submissions', payload);
+  return data;
 }
 
 export async function processSubmission(id: string): Promise<{ message: string; [key: string]: unknown }> {


### PR DESCRIPTION
## v97 Portal Fixes

### Root Cause
Backend enforces API key auth (\OPENINSURE_API_KEY\ env var), but nginx proxy was not forwarding the \X-API-Key\ header. All API calls returned 401/403, causing silent fallback to mock data.

### Bug 1 — Products page missing Cyber SMB
- **Before:** Only 5 mock products shown (mock fallback)
- **After:** All 8 real products from API, including *Cyber Liability — Small & Medium Business*

### Bug 2 — Clicking product did nothing
- **Before:** \getProduct()\ had no try/catch; API 401 → detail stayed undefined → no navigation
- **After:** Auth fixed → detail loads from real API. Added try/catch fallback for resilience.

### Bug 3 — Submissions created with \mock-\ prefix
- **Before:** \createSubmission()\ silently caught 401 errors and returned mock objects
- **After:** Removed mock fallback; errors propagate to UI toast. With auth fixed, POST succeeds.

### Changes
| File | Change |
|------|--------|
| \
ginx.conf\ | Add \proxy_set_header X-API-Key\ via envsubst |
| \Dockerfile\ | Template nginx.conf with envsubst at startup |
| \client.ts\ | Support \VITE_API_KEY\ for local dev |
| \products.ts\ | Add try/catch fallback to \getProduct()\ |
| \submissions.ts\ | Remove mock ID fallback from \createSubmission()\ |

### Deployed & Verified
- Image: \openinsure-dashboard:v97\
- Container App env var \OPENINSURE_API_KEY\ set
- Playwright E2E: all 3 bugs verified fixed on live site